### PR TITLE
Fixed issue with undefined document

### DIFF
--- a/index.js
+++ b/index.js
@@ -652,20 +652,24 @@ function props(p, q) {
 }
 
 function docForReply(doc) {
-  if (Array.isArray(doc)) {
-    doc = doc[0] === doc[1]._id ? doc[1] : doc[0];
-  }
+  if (doc != undefined) {
+    if (Array.isArray(doc)) {
+      doc = doc[0] === doc[1]._id ? doc[1] : doc[0];
+    }
 
-  if (doc._id) {
-    doc.id = doc._id;
-    delete doc._id;
-  }
-  if (doc._rev) {
-    doc.rev = doc._rev;
-    delete doc._rev;
-  }
+    if (doc._id) {
+      doc.id = doc._id;
+      delete doc._id;
+    }
+    if (doc._rev) {
+      doc.rev = doc._rev;
+      delete doc._rev;
+    }
 
-  return doc;
+    return doc;
+  } else {
+    return {};
+  }
 }
 
 function docForIngestion(doc) {


### PR DESCRIPTION
If we use couch db keys based querying and if key is not exist, then doc is undefined and it is crashing application. Handled it to return empty document.